### PR TITLE
Hotfix:Added requests to requirements.txt

### DIFF
--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Version 0.1.10 (hotfix)
+  * Included requests library in requirements.txt
+
 ## Version 0.1.9
   * Added "global" verbose option.  
   * Updated in-package schema and unit tests for VERIS version 1.3.4  

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ statsmodels>=0.9.0
 matplotlib>=2.2.2
 pandas>=0.23.0
 tqdm>=4.32.2
+requests>=2.23.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
 	name='verispy',
-	version= '0.1.9',
+	version= '0.1.10',
 	description='Parses VCDB json data into a Pandas DataFrame and provides summary functions and basic enumeration plotting.',
 	author='Tyler Byers',
 	author_email='tbyers@risklens.com',

--- a/verispy/__init__.py
+++ b/verispy/__init__.py
@@ -5,4 +5,4 @@
 
 from .veris import VERIS
 
-__version__ = '0.1.9'
+__version__ = '0.1.10'


### PR DESCRIPTION
I noticed that verispy doesn't auto-install the requests library when I install it on a fresh conda environment, yet it is a required library in the package. Threw together this hotfix to remedy that :-)