### PR TITLE
De-dupe incidents

### DIFF
--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Version 0.1.13  
+  * VCDB has a few duplicated incidents in its database now. This update drops those duplicates based on the `incident_id`.  
+  
 ## Version 0.1.12  
   * Updated in-package schema and unit tests for VERIS version 1.3.5  
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
 	name='verispy',
-	version= '0.1.12',
+	version= '0.1.13',
 	description='Parses VCDB json data into a Pandas DataFrame and provides summary functions and basic enumeration plotting.',
 	author='Tyler Byers',
 	author_email='tbyers@risklens.com',

--- a/verispy/__init__.py
+++ b/verispy/__init__.py
@@ -5,4 +5,4 @@
 
 from .veris import VERIS
 
-__version__ = '0.1.12'
+__version__ = '0.1.13'

--- a/verispy/veris.py
+++ b/verispy/veris.py
@@ -400,6 +400,12 @@ class VERIS(object):
 
         raw_df = self._rawjson_to_df(filenames)
 
+        # de-duplicate rows -- a few duplicate instances may happen
+        rows_before = raw_df.shape[0]
+        raw_df = raw_df.drop_duplicates(subset=['incident_id'])
+        rows_after = raw_df.shape[0]
+        if verbose: print('Dropped {} rows with duplicated incident_id values.'.format(rows_before-rows_after))
+
         if keep_raw: self.raw_df = raw_df
 
         # build the enumerations


### PR DESCRIPTION
## Version 0.1.13  
  * VCDB has a few duplicated incidents in its database now. This update drops those duplicates based on the `incident_id`.  